### PR TITLE
Fix strategy sorting bug

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -72,7 +72,10 @@ export async function getStrategies(): Promise<Strategy[]> {
   const { data, error } = await supabase
     .from('strategies')
     .select('*')
-    .order('votes', { ascending: false })
+    // order by creation time to show newest strategies first. The previous
+    // implementation attempted to sort by a non-existent `votes` column which
+    // resulted in a runtime error.
+    .order('created_at', { ascending: false })
   
   if (error) {
     console.error('Error fetching strategies:', error)


### PR DESCRIPTION
## Summary
- fix the `getStrategies` function in `supabase.ts` to order results by `created_at`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c23fbd7e08325a299cc256a2f78d2